### PR TITLE
add space to make split in github-exporter  works for multiple repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The REPOS variable can also be updated to point to the Repos that you wish to mo
         - 9171
       image: infinityworks/github-exporter:latest 
       environment:
-        - REPOS=freeCodeCamp/freeCodeCamp,docker/docker
+        - REPOS=freeCodeCamp/freeCodeCamp, docker/docker
         - GITHUB_TOKEN=<GitHub API Token see README>
       networks:
         - back-tier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - 9171:9171
     image: infinityworks/github-exporter:latest 
     environment:
-      - REPOS=freeCodeCamp/freeCodeCamp,docker/docker
+      - REPOS=freeCodeCamp/freeCodeCamp, docker/docker
       - GITHUB_TOKEN=<GitHub API Token see README>
     networks:
       - back-tier


### PR DESCRIPTION
right now github-exporter is using ", " (space after , ) to split multiple repositorieshttps://github.com/infinityworks/github-exporter/blob/master/config/config.go
